### PR TITLE
Fix Attempting to Burn Native Token

### DIFF
--- a/contracts/callpaths/WarmPath.sol
+++ b/contracts/callpaths/WarmPath.sol
@@ -60,17 +60,16 @@ contract WarmPath is MarketSequencer, SettleLayer, ProtocolAccount {
         require(reserveFlags < 0x4, "RF");
 
         if (base == address(0)) {
+            require(!isBurnOrHarvest(code), "WB");
             base = wbera;
             reserveFlags = 0x4;
         }
 
         if (quote == address(0)) {
+            require(!isBurnOrHarvest(code), "WB");
             quote = wbera;
             reserveFlags = 0x5;
         }
-        
-        // if (base == address(0)) { base = wbera; }
-        // else if ( quote == address(0)) { quote = wbera; }
 
         if (lpConduit == address(0)) { lpConduit = lockHolder_; }
         
@@ -221,5 +220,12 @@ contract WarmPath is MarketSequencer, SettleLayer, ProtocolAccount {
      *         in the correct slot. */
     function acceptCrocProxyRole (address, uint16 slot) public pure returns (bool) {
         return slot == CrocSlots.LP_PROXY_IDX;
+    }
+
+    function isBurnOrHarvest (uint8 code) internal pure returns (bool) {
+        return code == UserCmd.BURN_AMBIENT_LIQ_LP ||
+               code == UserCmd.BURN_AMBIENT_BASE_LP ||
+               code == UserCmd.BURN_AMBIENT_QUOTE_LP ||
+               code == UserCmd.HARVEST_LP;
     }
 }

--- a/etc/errors.json
+++ b/etc/errors.json
@@ -34,5 +34,6 @@
     "V": "Insufficient liquidity in level",
     "X": "Tick below max",
     "Y": "Lobby bitmap broken",
+    "WB": "Must use wrapped native token",
     "Z": "Not authorized for pool",
 }


### PR DESCRIPTION
Native token pools do not exist, and this override causes bad bug. This PR adds a check that we are performing a wrap on the native token.