### PR TITLE
Add queryPoolAmbientTokens lens function

### DIFF
--- a/contracts/lens/CrocQuery.sol
+++ b/contracts/lens/CrocQuery.sol
@@ -468,6 +468,23 @@ contract CrocQuery {
         }
     }
 
+    /* @notice Calculates the full range liquidity (base and quote reserves) for a given pool
+     * @param base The base token address
+     * @param quote The quote token address
+     * @param poolIdx The pool index
+     * @return liq The total amount of ambient sqrt(X*Y) liquidity 
+     * @return baseReserves The amount of base token reserves
+     * @return quoteReserves The amount of quote token reserves */
+    function queryPoolAmbientTokens(address base, address quote, uint256 poolIdx) 
+        external view returns (uint128 liq, uint128 baseQty, uint128 quoteQty) 
+    {
+        CurveMath.CurveState memory curve = queryCurve(base, quote, poolIdx);
+        liq = curve.activeLiquidity();
+        uint128 priceRoot = curve.priceRoot_;
+
+        (baseQty, quoteQty) = liquidityToTokens(priceRoot, liq);
+    }
+
     /* @notice Connverts an arbitrary liquidity seeds value to XYK liquidity and equivalent
      *         full-range tokens for that liquidity. */ 
     function convertSeedsToLiq (CurveMath.CurveState memory curve, uint128 seeds) 

--- a/test/TestCrocQuery.ts
+++ b/test/TestCrocQuery.ts
@@ -149,6 +149,23 @@ describe('CrocQuery', () => {
         expect(result.knockedOut).to.eq(false)
     })
 
+    it("post-knockout pos tokens", async() => {
+        await test.testMintAmbient(10*1024)
+        await test.testKnockoutMint(1000, true, 3200, 3200+32, false)
+        let pivot = (await hre.ethers.provider.getBlock("latest")).timestamp
+
+        await test.testSwap(false, true, 10000000, toSqrtPrice(1.0))
+        await test.testSwap(true, true, 10000000, toSqrtPrice(1.5))
+
+        let result = await query.queryKnockoutTokens(trader, 
+            baseToken.address, quoteToken.address, POOL_IDX,  pivot, true, 3200, 3200+32)
+
+        expect(result.liq).to.eq(516 * 1024)
+        expect(result.baseQty).to.eq(0)
+        expect(result.quoteQty).to.eq(720)
+        expect(result.knockedOut).to.eq(true)
+    })
+
     it("full range liquidity", async() => {
         await test.testMintAmbient(10000)
     

--- a/test/TestCrocQuery.ts
+++ b/test/TestCrocQuery.ts
@@ -49,7 +49,7 @@ describe('CrocQuery', () => {
 
         let result = await query.queryAmbientTokens(trader, 
             baseToken.address, quoteToken.address, POOL_IDX)
-        
+ 
         expect(result.liq).to.eq(10000*1024)
         expect(result.baseQty).to.eq(base)
         expect(result.quoteQty).to.eq(quote)        
@@ -149,21 +149,18 @@ describe('CrocQuery', () => {
         expect(result.knockedOut).to.eq(false)
     })
 
-    it("post-knockout pos tokens", async() => {
-        await test.testMintAmbient(10*1024)
-        await test.testKnockoutMint(1000, true, 3200, 3200+32, false)
-        let pivot = (await hre.ethers.provider.getBlock("latest")).timestamp
-
-        await test.testSwap(false, true, 10000000, toSqrtPrice(1.0))
-        await test.testSwap(true, true, 10000000, toSqrtPrice(1.5))
-
-        let result = await query.queryKnockoutTokens(trader, 
-            baseToken.address, quoteToken.address, POOL_IDX,  pivot, true, 3200, 3200+32)
-
-        expect(result.liq).to.eq(516 * 1024)
-        expect(result.baseQty).to.eq(0)
-        expect(result.quoteQty).to.eq(720)
-        expect(result.knockedOut).to.eq(true)
+    it("full range liquidity", async() => {
+        await test.testMintAmbient(10000)
+    
+        let baseExpected = await (await test.snapBaseOwed()).sub(MINT_BUFFER)
+        let quoteExpected = await (await test.snapQuoteOwed()).sub(MINT_BUFFER)
+    
+        let result = await query.queryPoolAmbientTokens(
+            baseToken.address, quoteToken.address, POOL_IDX
+        )
+    
+        expect(Number(result.baseQty)).to.be.closeTo(Number(baseExpected), 5)
+        expect(Number(result.quoteQty)).to.be.closeTo(Number(quoteExpected), 5)
     })
 
 })


### PR DESCRIPTION
Several projects/devs have asked for a way to query the quantity of tokens in reserve for a given pool. Currently, it's really cumbersome, requiring them to implement their own fixed point arithmetic.

This PR adds a view function 
`queryPoolAmbientTokens(address base, address quote, uint256 poolIdx)` 
to easily see a pool's:
1) liquidity
2) baseQty
3) quoteQty