### PR TITLE
ColdPath: move sudo command from coldPath to safeModePath to reduce contract size

### DIFF
--- a/contracts/CrocSwapDex.sol
+++ b/contracts/CrocSwapDex.sol
@@ -191,7 +191,7 @@ constructor(address initialWbera) CrocSwapDex(initialWbera) {
         proxyPaths_[CrocSlots.MICRO_PROXY_IDX] = address(new MicroPaths());
         proxyPaths_[CrocSlots.FLAG_CROSS_PROXY_IDX] = address(new KnockoutFlagPath());
         proxyPaths_[CrocSlots.KNOCKOUT_LP_PROXY_IDX] = address(new KnockoutLiqPath(initialWbera));
-        proxyPaths_[CrocSlots.SAFE_MODE_PROXY_PATH] = address(new SafeModePath(initialWbera));
+        proxyPaths_[CrocSlots.SAFE_MODE_PROXY_PATH] = address(new SafeModePath());
     }
 }
 

--- a/contracts/callpaths/ColdPath.sol
+++ b/contracts/callpaths/ColdPath.sol
@@ -38,7 +38,7 @@ contract ColdPath is MarketSequencer, DepositDesk, ProtocolAccount {
     constructor(address initialWbera) DepositDesk(initialWbera) {
     }
     /* @notice Consolidated method for protocol control related commands. */
-    function protocolCmd (bytes calldata cmd) virtual public {
+    function protocolCmd (bytes calldata cmd) public {
         uint8 code = uint8(cmd[31]);
 
         if (code == ProtocolCmd.DISABLE_TEMPLATE_CODE) {
@@ -58,34 +58,14 @@ contract ColdPath is MarketSequencer, DepositDesk, ProtocolAccount {
         } else if (code == ProtocolCmd.OFF_GRID_CODE) {
             pegPriceImprove(cmd);
         } else {
-            sudoCmd(cmd);
+            revert("Invalid command");
         }
 
         emit CrocEvents.CrocColdProtocolCmd(cmd);
     }
 
-    /* @notice Subset of highly privileged commands that are only allowed to run in sudo
-     *         mode. */
-    function sudoCmd (bytes calldata cmd) internal {
-        require(sudoMode_, "Sudo");
-        uint8 cmdCode = uint8(cmd[31]);
-        
-        if (cmdCode == ProtocolCmd.COLLECT_TREASURY_CODE) {
-            collectProtocol(cmd);
-        } else if (cmdCode == ProtocolCmd.SET_TREASURY_CODE) {
-            setTreasury(cmd);
-        } else if (cmdCode == ProtocolCmd.AUTHORITY_TRANSFER_CODE) {
-            transferAuthority(cmd);
-        } else if (cmdCode == ProtocolCmd.HOT_OPEN_CODE) {
-            setHotPathOpen(cmd);
-        } else if (cmdCode == ProtocolCmd.SAFE_MODE_CODE) {
-            setSafeMode(cmd);
-        } else {
-            revert("Invalid command");
-        }
-    }
     
-    function userCmd (bytes calldata cmd) virtual public payable {
+    function userCmd (bytes calldata cmd) public payable {
         uint8 cmdCode = uint8(cmd[31]);
         
         if (cmdCode == UserCmd.INIT_POOL_CODE) {
@@ -249,51 +229,6 @@ contract ColdPath is MarketSequencer, DepositDesk, ProtocolAccount {
         setPriceImprove(token, unitTickCollateral, awayTickTol);
     }
 
-    function setHotPathOpen (bytes calldata cmd) private {
-        (, bool open) = abi.decode(cmd, (uint8, bool));
-        emit CrocEvents.HotPathOpen(open);
-        hotPathOpen_ = open;        
-    }
-
-    function setSafeMode (bytes calldata cmd) private {
-        (, bool inSafeMode) = abi.decode(cmd, (uint8, bool));
-        emit CrocEvents.SafeMode(inSafeMode);
-        inSafeMode_ = inSafeMode;        
-    }
-
-    /* @notice Pays out the the protocol fees.
-     * @param token The token for which the accumulated fees are being paid out. 
-     *              (Or if 0x0 pays out native Ethereum.) */
-    function collectProtocol (bytes calldata cmd) private {
-        (, address token) = abi.decode(cmd, (uint8, address));
-
-        require(block.timestamp >= treasuryStartTime_, "Treasury start");
-        emit CrocEvents.ProtocolDividend(token, treasury_);
-        disburseProtocolFees(treasury_, token);
-    }
-
-    /* @notice Sets the treasury address to receive protocol fees. Once set, the treasury cannot
-     *         receive fees until 7 days after. */
-    function setTreasury (bytes calldata cmd) private {
-        (, address treasury) = abi.decode(cmd, (uint8, address));
-
-        require(treasury != address(0) && treasury.code.length != 0, "Treasury invalid");
-        treasury_ = treasury;
-        treasuryStartTime_ = uint64(block.timestamp + 7 days);
-        emit CrocEvents.TreasurySet(treasury_, treasuryStartTime_);
-    }
-
-    function transferAuthority (bytes calldata cmd) private {
-        (, address auth) =
-            abi.decode(cmd, (uint8, address));
-
-        require(auth != address(0) && auth.code.length > 0 && 
-            ICrocMaster(auth).acceptsCrocAuthority(), "Invalid Authority");
-        
-        emit CrocEvents.AuthorityTransfer(authority_);
-        authority_ = auth;
-    }
-
     /* @notice Used to directly pay out or pay in surplus collateral.
      * @param recv The address where the funds are paid to (only applies if surplus was
      *             paid out.)
@@ -368,7 +303,7 @@ contract ColdPath is MarketSequencer, DepositDesk, ProtocolAccount {
 
     /* @notice Used at upgrade time to verify that the contract is a valid Croc sidecar proxy and used
      *         in the correct slot. */
-    function acceptCrocProxyRole (address, uint16 slot) public virtual returns (bool) {
+    function acceptCrocProxyRole (address, uint16 slot) public pure returns (bool) {
         return slot == CrocSlots.COLD_PROXY_IDX;
     }
 }

--- a/contracts/callpaths/SafeModePath.sol
+++ b/contracts/callpaths/SafeModePath.sol
@@ -2,28 +2,90 @@
 
 pragma solidity 0.8.19;
 
-import './ColdPath.sol';
-
+import '../mixins/ProtocolAccount.sol';
+import '../libraries/ProtocolCmd.sol';
+import '../interfaces/ICrocMinion.sol';
+import '../CrocEvents.sol';
 /* @title Safe Mode Call Path.
  *
  * @notice Highly restricted callpath meant to be the sole point of entry when the dex
  *         contract has been forced into emergency safe mode. Essentially this retricts 
  *         all calls besides sudo mode admin actions. */
-contract SafeModePath is ColdPath {
+contract SafeModePath is ProtocolAccount {
 
-    constructor(address initialWbera) ColdPath(initialWbera) {}
-
-    function protocolCmd (bytes calldata cmd) override public {
-        sudoCmd(cmd);
+    /* @notice Subset of highly privileged commands that are only allowed to run in sudo
+     *         mode. */
+    function protocolCmd (bytes calldata cmd) public {
+        require(sudoMode_, "Sudo");
+        uint8 cmdCode = uint8(cmd[31]);
+        
+        if (cmdCode == ProtocolCmd.COLLECT_TREASURY_CODE) {
+            collectProtocol(cmd);
+        } else if (cmdCode == ProtocolCmd.SET_TREASURY_CODE) {
+            setTreasury(cmd);
+        } else if (cmdCode == ProtocolCmd.AUTHORITY_TRANSFER_CODE) {
+            transferAuthority(cmd);
+        } else if (cmdCode == ProtocolCmd.HOT_OPEN_CODE) {
+            setHotPathOpen(cmd);
+        } else if (cmdCode == ProtocolCmd.SAFE_MODE_CODE) {
+            setSafeMode(cmd);
+        } else {
+            revert("Invalid command");
+        }
     }
 
-    function userCmd (bytes calldata) override public payable {
+    function userCmd (bytes calldata) public payable {
         revert("Emergency Safe Mode");
+    }
+
+    function setHotPathOpen (bytes calldata cmd) private {
+        (, bool open) = abi.decode(cmd, (uint8, bool));
+        emit CrocEvents.HotPathOpen(open);
+        hotPathOpen_ = open;        
+    }
+
+    function setSafeMode (bytes calldata cmd) private {
+        (, bool inSafeMode) = abi.decode(cmd, (uint8, bool));
+        emit CrocEvents.SafeMode(inSafeMode);
+        inSafeMode_ = inSafeMode;        
+    }
+
+    /* @notice Pays out the the protocol fees.
+     * @param token The token for which the accumulated fees are being paid out. 
+     *              (Or if 0x0 pays out native Ethereum.) */
+    function collectProtocol (bytes calldata cmd) private {
+        (, address token) = abi.decode(cmd, (uint8, address));
+
+        require(block.timestamp >= treasuryStartTime_, "Treasury start");
+        emit CrocEvents.ProtocolDividend(token, treasury_);
+        disburseProtocolFees(treasury_, token);
+    }
+
+    /* @notice Sets the treasury address to receive protocol fees. Once set, the treasury cannot
+     *         receive fees until 7 days after. */
+    function setTreasury (bytes calldata cmd) private {
+        (, address treasury) = abi.decode(cmd, (uint8, address));
+
+        require(treasury != address(0) && treasury.code.length != 0, "Treasury invalid");
+        treasury_ = treasury;
+        treasuryStartTime_ = uint64(block.timestamp + 7 days);
+        emit CrocEvents.TreasurySet(treasury_, treasuryStartTime_);
+    }
+
+    function transferAuthority (bytes calldata cmd) private {
+        (, address auth) =
+            abi.decode(cmd, (uint8, address));
+
+        require(auth != address(0) && auth.code.length > 0 && 
+            ICrocMaster(auth).acceptsCrocAuthority(), "Invalid Authority");
+        
+        emit CrocEvents.AuthorityTransfer(authority_);
+        authority_ = auth;
     }
 
     /* @notice Used at upgrade time to verify that the contract is a valid Croc sidecar proxy and used
      *         in the correct slot. */
-    function acceptCrocProxyRole (address, uint16 slot) public pure override returns (bool) {
+    function acceptCrocProxyRole (address, uint16 slot) public pure returns (bool) {
         return slot == CrocSlots.SAFE_MODE_PROXY_PATH;
     }
 }

--- a/contracts/governance/CrocPolicy.sol
+++ b/contracts/governance/CrocPolicy.sol
@@ -157,10 +157,10 @@ contract CrocPolicy is ICrocMaster {
         emit CrocEmergencyHalt(minion, reason);
 
         bytes memory cmd = ProtocolCmd.encodeHotPath(false);
-        ICrocMinion(minion).protocolCmd(CrocSlots.COLD_PROXY_IDX, cmd, true);
+        ICrocMinion(minion).protocolCmd(CrocSlots.SAFE_MODE_PROXY_PATH, cmd, true);
         
         cmd = ProtocolCmd.encodeSafeMode(true);
-        ICrocMinion(minion).protocolCmd(CrocSlots.COLD_PROXY_IDX, cmd, true);
+        ICrocMinion(minion).protocolCmd(CrocSlots.SAFE_MODE_PROXY_PATH, cmd, true);
     }
 
     /* @notice Croc policy rules are set on a per address basis. Each address 


### PR DESCRIPTION
motive is to reduce the contract size of coldPath, right now its around 32 Kb and deployment is failing.

pending

- modification in CrocPolicy to use safeModePath slot for sudo command instead of coldPath